### PR TITLE
Fix file headers and footer for ELPA compatibility

### DIFF
--- a/evil-leader.el
+++ b/evil-leader.el
@@ -7,7 +7,7 @@
 ;; Created: 2011-09-13
 ;; Version: 0.1
 ;; Keywords: evil vim-emulation leader
-;; Package-Requires: ((evil))
+;; Package-Requires: ((evil "0"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -115,4 +115,4 @@ The combination has to be readable by `read-kbd-macro'."
 (put 'evil-leader/set-key 'lisp-indent-function 'defun)
 
 (provide 'evil-leader)
-;;; evil-numbers.el ends here
+;;; evil-leader.el ends here


### PR DESCRIPTION
The problems fixed by this commit are the reason `evil-leader` barely scrapes into Melpa with a "No description available" comment. :-)

Related: a good test of whether an .el file is well-formatted for publishing to an ELPA archive is to run `M-: (package-buffer-info)` -- if no error is raised, you're pretty much good to go. :-)
